### PR TITLE
feat(seo): fundações técnicas de SEO e structured data

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { FaArrowLeft } from "react-icons/fa";
 import { BlogMarkdown } from "@/components/blog-markdown";
 import { Reveal } from "@/components/ui/reveal";
 import { getAllPostSlugs, getPostBySlug, getRecentPosts } from "@/lib/posts";
+import { absoluteUrl, siteConfig, siteUrl } from "@/lib/site";
 
 type BlogPostPageProps = {
   params: Promise<{ slug: string }>;
@@ -58,11 +59,16 @@ export async function generateMetadata({
   return {
     title: `${post.title} — Philipe Morais`,
     description: post.description,
+    alternates: {
+      canonical: `/blog/${post.slug}`,
+    },
     openGraph: {
       title: `${post.title} — Philipe Morais`,
       description: post.description,
       type: "article",
+      url: absoluteUrl(`/blog/${post.slug}`),
       publishedTime: post.date,
+      authors: [siteConfig.author.name],
       tags: [post.theme],
     },
     twitter: {
@@ -86,8 +92,37 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     .filter((item) => item.slug !== post.slug)
     .slice(0, 3);
 
+  const articleJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    description: post.description,
+    datePublished: post.date,
+    dateModified: post.date,
+    inLanguage: "pt-BR",
+    url: absoluteUrl(`/blog/${post.slug}`),
+    mainEntityOfPage: absoluteUrl(`/blog/${post.slug}`),
+    image: `${siteUrl}/opengraph-image`,
+    author: {
+      "@type": "Person",
+      name: siteConfig.author.name,
+      url: siteUrl,
+    },
+    publisher: {
+      "@type": "Person",
+      name: siteConfig.author.name,
+      url: siteUrl,
+    },
+    articleSection: post.theme,
+  };
+
   return (
     <main className="mx-auto max-w-3xl px-6 py-12 md:py-16">
+      <script
+        type="application/ld+json"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD estático controlado
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+      />
       <Link
         href="/"
         className="flex items-center gap-2 text-sm text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { DM_Sans } from "next/font/google";
 import "./globals.css";
+import { siteConfig, siteUrl } from "@/lib/site";
 import { cn } from "@/lib/utils";
 import { ThemeProvider } from "@/providers/theme-provider";
 
@@ -11,44 +12,84 @@ const dmSans = DM_Sans({
 });
 
 export const metadata: Metadata = {
-  title: "Philipe Morais - Desenvolvedor Frontend & UX/UI Designer",
-  description:
-    "Desenvolvedor front-end que contribui para tornar a internet mais criativa, acessível e um lugar melhor. Especializado em React, Next.js, TypeScript e web design.",
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: siteConfig.title,
+    template: "%s — Philipe Morais",
+  },
+  description: siteConfig.description,
   keywords: [
-    "frontend",
-    "developer",
+    "Philipe Morais",
+    "desenvolvedor frontend",
+    "frontend developer",
     "react",
     "next.js",
     "typescript",
     "web design",
+    "ux/ui designer",
+    "desenvolvedor front-end brasil",
   ],
+  authors: [{ name: siteConfig.author.name, url: siteUrl }],
+  creator: siteConfig.author.name,
+  alternates: {
+    canonical: "/",
+  },
   robots: {
     index: true,
     follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
   },
   openGraph: {
-    title: "Philipe Morais - Desenvolvedor Frontend & UX/UI Designer",
-    description:
-      "Desenvolvedor front-end que contribui para tornar a internet mais criativa, acessível e um lugar melhor.",
+    title: siteConfig.title,
+    description: siteConfig.description,
     type: "website",
-    url: "https://philipemorais.com",
-    siteName: "Philipe Morais",
-    images: [
-      {
-        url: "https://philipemorais.com/images/og-image.png",
-        width: 1200,
-        height: 630,
-        alt: "Philipe Morais - Desenvolvedor Frontend & UX/UI Designer",
-      },
-    ],
+    url: siteUrl,
+    siteName: siteConfig.name,
+    locale: siteConfig.locale,
   },
   twitter: {
     card: "summary_large_image",
-    title: "Philipe Morais - Desenvolvedor Frontend & UX/UI Designer",
-    description:
-      "Desenvolvedor front-end que contribui para tornar a internet mais criativa, acessível e um lugar melhor.",
-    images: ["https://philipemorais.com/images/og-image.png"],
+    title: siteConfig.title,
+    description: siteConfig.description,
   },
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Person",
+      "@id": `${siteUrl}/#person`,
+      name: siteConfig.author.name,
+      url: siteUrl,
+      jobTitle: siteConfig.author.jobTitle,
+      email: `mailto:${siteConfig.author.email}`,
+      image: `${siteUrl}/opengraph-image`,
+      sameAs: siteConfig.author.sameAs,
+      knowsAbout: [
+        "React",
+        "Next.js",
+        "TypeScript",
+        "Web Design",
+        "UX/UI Design",
+      ],
+    },
+    {
+      "@type": "WebSite",
+      "@id": `${siteUrl}/#website`,
+      url: siteUrl,
+      name: siteConfig.name,
+      description: siteConfig.description,
+      inLanguage: "pt-BR",
+      publisher: { "@id": `${siteUrl}/#person` },
+    },
+  ],
 };
 
 export default function RootLayout({
@@ -66,6 +107,11 @@ export default function RootLayout({
         suppressHydrationWarning
         className="flex min-h-full select-none flex-col"
       >
+        <script
+          type="application/ld+json"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD estático controlado
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,64 @@
+import { ImageResponse } from "next/og";
+import { siteConfig } from "@/lib/site";
+
+export const alt = siteConfig.title;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        padding: "80px",
+        background: "#0a0a0a",
+        color: "#fafafa",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          fontSize: 26,
+          letterSpacing: "0.2em",
+          textTransform: "uppercase",
+          color: "#a1a1aa",
+        }}
+      >
+        philipemorais.com
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+        <div style={{ display: "flex", fontSize: 84, fontWeight: 700 }}>
+          Philipe Morais
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 40,
+            fontWeight: 400,
+            color: "#d4d4d8",
+          }}
+        >
+          Desenvolvedor Frontend & UX/UI Designer
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          gap: "16px",
+          fontSize: 26,
+          color: "#a1a1aa",
+        }}
+      >
+        React · Next.js · TypeScript · Web Design
+      </div>
+    </div>,
+    { ...size },
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { absoluteUrl } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: absoluteUrl("/sitemap.xml"),
+    host: absoluteUrl("/"),
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,35 @@
+import type { MetadataRoute } from "next";
+import { getRecentPosts } from "@/lib/posts";
+import { projects } from "@/lib/projects";
+import { absoluteUrl } from "@/lib/site";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: absoluteUrl("/"),
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+  ];
+
+  const postRoutes: MetadataRoute.Sitemap = getRecentPosts(1000).map(
+    (post) => ({
+      url: absoluteUrl(`/blog/${post.slug}`),
+      lastModified: post.date ? new Date(post.date) : now,
+      changeFrequency: "yearly",
+      priority: 0.7,
+    }),
+  );
+
+  const projectRoutes: MetadataRoute.Sitemap = projects.map((project) => ({
+    url: absoluteUrl(`/work/${project.slug}`),
+    lastModified: now,
+    changeFrequency: "yearly",
+    priority: 0.8,
+  }));
+
+  return [...staticRoutes, ...postRoutes, ...projectRoutes];
+}

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/logos";
 import { OncineAnimatedBackground } from "@/components/ui/oncine-animated-background";
 import { getAllProjectSlugs, getProjectBySlug } from "@/lib/projects";
+import { absoluteUrl, siteConfig, siteUrl } from "@/lib/site";
 
 type WorkPageProps = {
   params: Promise<{ slug: string }>;
@@ -40,11 +41,14 @@ export async function generateMetadata({
   return {
     title: `${project.title} — Philipe Morais`,
     description: project.description,
+    alternates: {
+      canonical: `/work/${project.slug}`,
+    },
     openGraph: {
       title: `${project.title} — Philipe Morais`,
       description: project.description,
       type: "website",
-      ...(project.website ? { url: project.website } : {}),
+      url: absoluteUrl(`/work/${project.slug}`),
     },
     twitter: {
       card: "summary_large_image",
@@ -103,11 +107,34 @@ export default async function WorkPage({ params }: WorkPageProps) {
 
   const techLogos = project.stack.filter((t) => techLogoMap[t]);
 
+  const projectJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "CreativeWork",
+    name: project.title,
+    headline: project.headline,
+    description: project.description,
+    url: absoluteUrl(`/work/${project.slug}`),
+    inLanguage: "pt-BR",
+    dateCreated: project.year,
+    keywords: project.stack.join(", "),
+    ...(project.website ? { sameAs: project.website } : {}),
+    creator: {
+      "@type": "Person",
+      name: siteConfig.author.name,
+      url: siteUrl,
+    },
+  };
+
   return (
     <main
       className={`relative min-h-screen ${project.textClassName}`}
       style={{ background: project.background }}
     >
+      <script
+        type="application/ld+json"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD estático controlado
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(projectJsonLd) }}
+      />
       {project.slug === "oncine" ? <OncineAnimatedBackground /> : null}
       {project.slug === "colorspace" ? <ColorspaceAnimatedBackground /> : null}
 

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,29 @@
+const rawSiteUrl =
+  process.env.NEXT_PUBLIC_SERVER_URL ?? "https://philipemorais.com";
+
+// Normaliza removendo barra final para evitar URLs com "//" no sitemap/canonical.
+export const siteUrl = rawSiteUrl.replace(/\/$/, "");
+
+export const siteConfig = {
+  name: "Philipe Morais",
+  title: "Philipe Morais - Desenvolvedor Frontend & UX/UI Designer",
+  description:
+    "Desenvolvedor front-end que contribui para tornar a internet mais criativa, acessível e um lugar melhor. Especializado em React, Next.js, TypeScript e web design.",
+  url: siteUrl,
+  locale: "pt_BR",
+  author: {
+    name: "Philipe Morais",
+    jobTitle: "Desenvolvedor Frontend & UX/UI Designer",
+    email: "contato@philipemorais.com",
+    sameAs: [
+      "https://github.com/PhMoraiis",
+      "https://www.linkedin.com/in/ph-morais",
+      "https://www.instagram.com/philipemoraiis",
+    ],
+  },
+} as const;
+
+// URL absoluta a partir de um path relativo.
+export function absoluteUrl(path = "/") {
+  return `${siteUrl}${path.startsWith("/") ? path : `/${path}`}`;
+}


### PR DESCRIPTION
## Resumo

Melhorias de SEO no portfólio, focando nas fundações técnicas de crawl/indexação e correção de um bug crítico de social preview.

### Correções

- **OG image quebrada (404)** → nova rota `app/opengraph-image.tsx` gera imagem 1200×630 dinamicamente, válida para todas as rotas. A referência anterior apontava para `/images/og-image.png`, que não existia.
- **`robots.txt`** → nova `app/robots.ts` com referência ao sitemap.
- **`sitemap.xml`** → nova `app/sitemap.ts` dinâmica (home + posts + projetos).
- **`metadataBase` + canonical** → URLs OG/canonical resolvem de forma confiável; canonical em todas as páginas.
- **Structured data (JSON-LD)**:
  - Home: `Person` + `WebSite` (sameAs para GitHub/LinkedIn/Instagram)
  - Blog: `BlogPosting`
  - Work: `CreativeWork`
- **`lib/site.ts`** → config central (URL, autor, redes sociais).

### Validação

- `biome check` limpo nos arquivos alterados
- `next build` com sucesso — rotas `/robots.txt`, `/sitemap.xml`, `/opengraph-image` geradas

### Próximos passos (fora deste PR)

- Verificar domínio no Google Search Console e submeter o sitemap
- Ampliar conteúdo do blog (hoje só 1 post)
- Medir Core Web Vitals pós-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)