### PR TITLE
content(work): corrige copy do projeto OnCine

### DIFF
--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -33,9 +33,9 @@ export const projects: readonly Project[] = [
   {
     slug: "oncine",
     title: "OnCine",
-    headline: "Gestão de assinaturas e pagamentos recorrentes.",
+    headline: "Horários de cinema em tempo real, com sessões planejadas.",
     description:
-      "Produto em desenvolvimento para monitorar assinaturas, centralizar cobrancas e simplificar o controle financeiro mensal.",
+      "Produto em desenvolvimento que centraliza os horários da rede CineFlix em tempo real e planeja sessões consecutivas em poucos toques.",
     paragraphs: [
       "O OnCine resolve uma frustração real de quem frequenta cinema: descobrir os horários certos, encaixar sessões consecutivas e nunca perder a cena de abertura por ter chegado tarde. O OnCine centraliza listagens em tempo real de todos os cinemas da rede CineFlix e entrega planejamento inteligente em poucos toques.",
       "Contruí o OnCine do zero, da arquitetura de dados à interface. O foco da experiência é reduzir o atrito entre a vontade de ir ao cinema e a decisão de comprar o ingresso, com recomendações que se adaptam ao contexto do usuário.",


### PR DESCRIPTION
## Resumo

O headline do **OnCine** — *"Gestão de assinaturas e pagamentos recorrentes"* — e a description descreviam um gestor de assinaturas, o que não corresponde ao produto. Os próprios parágrafos já descrevem o real: um **agregador de horários de cinema em tempo real da rede CineFlix, com planejamento de sessões**.

### Mudanças (`lib/projects.ts`)

- **Headline**: `Gestão de assinaturas e pagamentos recorrentes.` → `Horários de cinema em tempo real, com sessões planejadas.`
- **Description** (metadata/OG de `/work/oncine`): reescrita para descrever o produto real

### Validação

- `biome check` limpo
- `next build` com sucesso

🤖 Generated with [Claude Code](https://claude.com/claude-code)